### PR TITLE
Updated gitignore to ignore object file and executable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,46 @@ cmake-build-debug/
 
 # Build Directories for Windows
 SFML-2.5.0-win64/
+
+# Created by https://www.gitignore.io/api/c++
+
+### C++ ###
+# Prerequisites
+*.d
+
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Fortran module files
+*.mod
+*.smod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app
+
+
+# End of https://www.gitignore.io/api/c++
+
+# Ignore the executable file
+nomb
+


### PR DESCRIPTION
I updated the .gitignore to stop looking for object files and the executable file.